### PR TITLE
#56 : Fixed Tradeskill bar colors + updated HS List.

### DIFF
--- a/modules/tradeskill.lua
+++ b/modules/tradeskill.lua
@@ -161,9 +161,10 @@ function TradeskillModule:StyleTradeskillFrame(prefix)
     self[prefix..'Text']:SetPoint('LEFT', self[prefix..'Icon'], 'RIGHT', 5, 0)
   else
     self[prefix..'Text']:SetPoint('TOPLEFT', self[prefix..'Icon'], 'TOPRIGHT', 5, 0)
-    self[prefix..'Bar']:SetStatusBarTexture(1, 1, 1)
+    self[prefix..'Bar']:SetStatusBarTexture("Interface/BUTTONS/WHITE8X8")
     if db.modules.tradeskill.barCC then
-      self[prefix..'Bar']:SetStatusBarColor(xb:GetClassColors())
+      rPerc, gPerc, bPerc, argbHex = xb:GetClassColors()
+      self[prefix..'Bar']:SetStatusBarColor(rPerc, gPerc, bPerc, 1)
     else
       self[prefix..'Bar']:SetStatusBarColor(xb:GetColor('normal'))
     end

--- a/modules/travel.lua
+++ b/modules/travel.lua
@@ -13,6 +13,14 @@ function TravelModule:OnInitialize()
   self.iconPath = xb.constants.mediaPath..'datatexts\\repair'
   self.garrisonHearth = 110560
   self.hearthstones = {
+    193588, -- Timewalker's Hearthstone
+    190237, -- Broker Translocation Matrix
+    188952, -- Dominated Hearthstone
+    184353, -- Kyrian Hearthstone
+    182773, -- Necrolord Hearthstone
+    180290, -- Night Fae Hearthstone
+    183716, -- Venthyr Sinstone
+    172179, -- Eternal Travaler's Hearthstone
     6948,   -- Hearthstone
     64488,  -- Innkeeper's Daughter
     28585,  -- Ruby Slippers

--- a/modules/travel.lua
+++ b/modules/travel.lua
@@ -13,6 +13,8 @@ function TravelModule:OnInitialize()
   self.iconPath = xb.constants.mediaPath..'datatexts\\repair'
   self.garrisonHearth = 110560
   self.hearthstones = {
+    6948,   -- Hearthstone
+    64488,  -- Innkeeper's Daughter
     193588, -- Timewalker's Hearthstone
     190237, -- Broker Translocation Matrix
     188952, -- Dominated Hearthstone
@@ -21,8 +23,6 @@ function TravelModule:OnInitialize()
     180290, -- Night Fae Hearthstone
     183716, -- Venthyr Sinstone
     172179, -- Eternal Travaler's Hearthstone
-    6948,   -- Hearthstone
-    64488,  -- Innkeeper's Daughter
     28585,  -- Ruby Slippers
     54452,  -- Ethereal Portal
     93672,  -- Dark Portal

--- a/modules/travel.lua
+++ b/modules/travel.lua
@@ -18,11 +18,6 @@ function TravelModule:OnInitialize()
     193588, -- Timewalker's Hearthstone
     190237, -- Broker Translocation Matrix
     188952, -- Dominated Hearthstone
-    184353, -- Kyrian Hearthstone
-    182773, -- Necrolord Hearthstone
-    180290, -- Night Fae Hearthstone
-    183716, -- Venthyr Sinstone
-    172179, -- Eternal Travaler's Hearthstone
     28585,  -- Ruby Slippers
     54452,  -- Ethereal Portal
     93672,  -- Dark Portal


### PR DESCRIPTION
- Fixed Tradeskill bar colors ([#56](https://github.com/Kozoaku/XIV_Databar/issues/56))
- Added Shadowlands Hearthstones to list in travel.lua